### PR TITLE
fix: emit declaration at package types path

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,7 @@ export default {
     typescript({
       declaration: true,
       declarationDir: dirname(pkg.exports.import),
+      rootDir: "guest-js",
     }),
   ],
   external: [


### PR DESCRIPTION
## Summary
- set the TypeScript plugin `rootDir` to `guest-js`
- make declaration output land at `dist-js/index.d.ts`, matching the package `types` and export metadata

## Why
The published `@choochmeque/tauri-plugin-sharekit-api@0.4.0-rc.3` tarball contains `dist-js/guest-js/index.d.ts`, but package metadata points to `dist-js/index.d.ts`. Consumers resolving the advertised `types` path get a missing file.

## Validation
- `npm pack @choochmeque/tauri-plugin-sharekit-api@0.4.0-rc.3 --silent` confirmed `package/dist-js/index.d.ts` is absent and `package/dist-js/guest-js/index.d.ts` is present
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm build`
- verified `dist-js/index.d.ts` is emitted
- `git diff --check`