### PR TITLE
Migrate example buildSrc off Project.exec for Gradle 9

### DIFF
--- a/examples/share-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/BuildTask.kt
+++ b/examples/share-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/BuildTask.kt
@@ -5,10 +5,17 @@ import org.gradle.api.GradleException
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+import org.gradle.process.ExecOperations
 
-open class BuildTask : DefaultTask() {
+abstract class BuildTask : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     @Input
     var rootDirRel: String? = null
+    @Input
+    var projectDir: String? = null
     @Input
     var target: String? = null
     @Input
@@ -27,7 +34,7 @@ open class BuildTask : DefaultTask() {
                     "$executable.cmd",
                     "$executable.bat",
                 )
-                
+
                 var lastException: Exception = e
                 for (fallback in fallbacks) {
                     try {
@@ -50,13 +57,13 @@ open class BuildTask : DefaultTask() {
         val release = release ?: throw GradleException("release cannot be null")
         val args = listOf("tauri", "android", "android-studio-script");
 
-        project.exec {
-            workingDir(File(project.projectDir, rootDirRel))
+        execOperations.exec {
+            workingDir(File(projectDir, rootDirRel))
             executable(executable)
             args(args)
-            if (project.logger.isEnabled(LogLevel.DEBUG)) {
+            if (logger.isEnabled(LogLevel.DEBUG)) {
                 args("-vv")
-            } else if (project.logger.isEnabled(LogLevel.INFO)) {
+            } else if (logger.isEnabled(LogLevel.INFO)) {
                 args("-v")
             }
             if (release) {

--- a/examples/share-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/RustPlugin.kt
+++ b/examples/share-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/RustPlugin.kt
@@ -63,13 +63,14 @@ open class RustPlugin : Plugin<Project> {
                     val targetName = targetPair.value
                     val targetArch = archList[targetPair.index]
                     val targetArchCapitalized = targetArch.replaceFirstChar { it.uppercase() }
-                    val targetBuildTask = project.tasks.maybeCreate(
+                    val targetBuildTask = project.tasks.register(
                         "rustBuild$targetArchCapitalized$profileCapitalized",
                         BuildTask::class.java
-                    ).apply {
+                    ) {
                         group = TASK_GROUP
                         description = "Build dynamic library in $profile mode for $targetArch"
                         rootDirRel = config.rootDirRel
+                        projectDir = project.projectDir.path
                         target = targetName
                         release = profile == "release"
                     }


### PR DESCRIPTION
Prepares the example app's `buildSrc` for Gradle 9.

Gradle 9 removes `Project.exec` and forbids reaching `Task.project` at execution time, which is what `BuildTask` used to run `tauri android android-studio-script`. The build tasks now:

- inject `ExecOperations` and call `execOperations.exec { … }` instead of `project.exec`
- take the project directory as an `@Input` captured at configuration time instead of `project.projectDir`
- use the task's own `logger` instead of `project.logger`
- are registered lazily (`tasks.register`) with their configuration in the action; `BuildTask` is `abstract` so Gradle can inject the service

No behaviour change under the current wrapper; the Gradle 9 / Kotlin plugin bumps build cleanly on top of it.