### PR TITLE
Align publish.yml apt setup with checks.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,11 +69,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Refresh the apt index first — with a stale index the cache action 404s
+      # and silently installs nothing.
+      - run: sudo apt-get update
+
       - name: Cache and install APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf llvm-dev clang cmake grcov
-          version: "1.0"  # bump this to invalidate the cache when needed
+          packages: libglib2.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf llvm-dev clang cmake grcov
+          version: "1.2"  # bump this to invalidate the cache when needed
 
       # Toolchain
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Aligns `publish.yml`'s apt setup with what `checks.yml` and `build-demo.yml` already do:

- `sudo apt-get update` before the apt cache action — with a stale index the action 404s and silently installs nothing
- `libglib2.0-dev` added to the package list (`cargo publish --dry-run` builds the crate and needs the glib headers)
- cache key bumped to `1.2`

Without this, the tag-triggered publish job can fail after the release tag is already pushed.